### PR TITLE
Fix style to conform to Google's style guidelines

### DIFF
--- a/src/autodetect.cc
+++ b/src/autodetect.cc
@@ -1,109 +1,102 @@
-#include <stdio.h>
-#include <string>
+/* Copyright 2012 Leonhardt Wille */
 
 #include <gphoto2/gphoto2-camera.h>
+#include <stdio.h>
+#include <string>
+#include "binding.h"  // NOLINT
 
-#include "binding.h"
-
-/*
+/**
  * This detects all currently attached cameras and returns
  * them in a list. It avoids the generic usb: entry.
  *
  * This function does not open nor initialize the cameras yet.
  */
-int
-autodetect (CameraList *list, GPContext *context, GPPortInfoList **portinfolist, CameraAbilitiesList	**abilities) {
-	int			ret, i;
-	CameraList		*xlist = NULL;
-	ret = gp_list_new (&xlist);
-	if (ret < GP_OK) goto out;
-	if (!*portinfolist) {
-		/* Load all the port drivers we have... */
-		ret = gp_port_info_list_new (portinfolist);
-		if (ret < GP_OK) goto out;
-		ret = gp_port_info_list_load (*portinfolist);
-		if (ret < 0) goto out;
-		ret = gp_port_info_list_count (*portinfolist);
-		if (ret < 0) goto out;
-	}
-	/* Load all the camera drivers we have... */
-	ret = gp_abilities_list_new (abilities);
-	if (ret < GP_OK) goto out;
-	ret = gp_abilities_list_load (*abilities, context);
-	if (ret < GP_OK) goto out;
 
-	/* ... and autodetect the currently attached cameras. */
-  ret = gp_abilities_list_detect (*abilities, *portinfolist, xlist, context);
-  
-	if (ret < GP_OK) goto out;
+int autodetect(CameraList *list, GPContext *context,
+               GPPortInfoList **portinfolist,
+               CameraAbilitiesList  **abilities) {
+  int ret, i;
+  CameraList *xlist = NULL;
+  ret = gp_list_new(&xlist);
+  if (ret < GP_OK) goto out;
+  if (!*portinfolist) {
+    /* Load all the port drivers we have... */
+    ret = gp_port_info_list_new(portinfolist);
+    if (ret < GP_OK) goto out;
+    ret = gp_port_info_list_load(*portinfolist);
+    if (ret < 0) goto out;
+    ret = gp_port_info_list_count(*portinfolist);
+    if (ret < 0) goto out;
+  }
+  /* Load all the camera drivers we have... */
+  ret = gp_abilities_list_new(abilities);
+  if (ret < GP_OK) goto out;
+  ret = gp_abilities_list_load(*abilities, context);
+  if (ret < GP_OK) goto out;
 
-	/* Filter out the "usb:" entry */
-  ret = gp_list_count (xlist);
-  
-	if (ret < GP_OK) goto out;
-	for (i=0;i<ret;i++) {
-		const char *name, *value;
-    
-		gp_list_get_name (xlist, i, &name);
-		gp_list_get_value (xlist, i, &value);
-		if (!strcmp ("usb:",value)) continue;
-		gp_list_append (list, name, value);
-	}
-out:
-	gp_list_free (xlist);
-	return gp_list_count(list);
+  /* ... and autodetect the currently attached cameras. */
+  ret = gp_abilities_list_detect(*abilities, *portinfolist, xlist, context);
+
+  if (ret < GP_OK) goto out;
+
+  /* Filter out the "usb:" entry */
+  ret = gp_list_count(xlist);
+
+  if (ret < GP_OK) goto out;
+  for (i = 0; i < ret; i++) {
+    const char *name, *value;
+    gp_list_get_name(xlist, i, &name);
+    gp_list_get_value(xlist, i, &value);
+    if (!strcmp("usb:", value)) continue;
+    gp_list_append(list, name, value);
+  }
+  out:
+    gp_list_free(xlist);
+    return gp_list_count(list);
 }
 
-/*
+/**
  * This function opens a camera depending on the specified model and port.
  */
-int
-open_camera (Camera ** camera, std::string model, std::string port, GPPortInfoList *portinfolist, CameraAbilitiesList	*abilities) {
-	int		ret, m, p;
-	CameraAbilities	a;
-	GPPortInfo	pi;
-  // printf("Opening camera using %p\n", camera);
-	ret = gp_camera_new (camera);
-  // printf("Created new camera handle %d, %p\n", ret, *camera);
-	if (ret < GP_OK) return ret;
 
-	/* First lookup the model / driver */
-  m = gp_abilities_list_lookup_model (abilities, model.c_str());
+int open_camera(Camera **camera, std::string model, std::string port,
+                GPPortInfoList *portinfolist, CameraAbilitiesList *abilities) {
+  int ret, m, p;
+  CameraAbilities a;
+  GPPortInfo  pi;
+  // printf("Opening camera using %p\n", camera);
+  ret = gp_camera_new(camera);
+  // printf("Created new camera handle %d, %p\n", ret, *camera);
+  if (ret < GP_OK) return ret;
+
+  /* First lookup the model / driver */
+  m = gp_abilities_list_lookup_model(abilities, model.c_str());
   // printf("looked up model %d\n", m);
-	if (m < GP_OK) return ret;
-  ret = gp_abilities_list_get_abilities (abilities, m, &a);
+  if (m < GP_OK) return ret;
+  ret = gp_abilities_list_get_abilities(abilities, m, &a);
   // printf("looked up abilities %d\n", ret);
-	if (ret < GP_OK) return ret;
-  ret = gp_camera_set_abilities (*camera, a);
+  if (ret < GP_OK) return ret;
+  ret = gp_camera_set_abilities(*camera, a);
   // printf("set abilities %d\n", ret);
 
-	if (ret < GP_OK) return ret;
-
-	/* Then associate the camera with the specified port */
-  p = gp_port_info_list_lookup_path (portinfolist, port.c_str());
   if (ret < GP_OK) return ret;
-  switch (p) {
-  case GP_ERROR_UNKNOWN_PORT:
-          fprintf (stderr, "The port you specified "
-                  "('%s') can not be found. Please "
-                  "specify one of the ports found by "
-                  "'gphoto2 --list-ports' and make "
-                  "sure the spelling is correct "
-                  "(i.e. with prefix 'serial:' or 'usb:').",
-                          port.c_str());
-          break;
-  default:
-          break;
+
+  /* Then associate the camera with the specified port */
+  p = gp_port_info_list_lookup_path(portinfolist, port.c_str());
+  if (ret < GP_OK) return ret;
+  if (p == GP_ERROR_UNKNOWN_PORT) {
+    fprintf(stderr, "The port you specified ('%s') can not be found. Please "
+            "specify one of the ports found by 'gphoto2 --list-ports' and "
+            "make sure the spelling is correct (i.e. with prefix 'serial:' "
+            "or 'usb:').", port.c_str());
   }
   if (ret < GP_OK) return ret;
-  ret = gp_port_info_list_get_info (portinfolist, p, &pi);
-  //printf("port_info_list_get_info %d\n", ret);
+  ret = gp_port_info_list_get_info(portinfolist, p, &pi);
+  // printf("port_info_list_get_info %d\n", ret);
   if (ret < GP_OK) return ret;
-  ret = gp_camera_set_port_info (*camera, pi);
-  //printf("gp_camera_set_port_info %d\n", ret);
-  
+  ret = gp_camera_set_port_info(*camera, pi);
+  // printf("gp_camera_set_port_info %d\n", ret);
   if (ret < GP_OK) return ret;
-  //printf("open_camera finished %d\n", ret);
-
-	return GP_OK;
+  // printf("open_camera finished %d\n", ret);
+  return GP_OK;
 }

--- a/src/binding.cc
+++ b/src/binding.cc
@@ -1,15 +1,14 @@
-#include "gphoto.h"
-#include "camera.h"
+/* Copyright 2012 Leonhardt Wille */
+
+#include "camera.h"  // NOLINT
+#include "gphoto.h"  // NOLINT
 
 extern "C" {
-  void init(Handle<Object> target)
-  {
-      HandleScope scope;
-      GPhoto2::Initialize(target);
-      GPCamera::Initialize(target);
+  void init(Handle<Object> target) {
+    HandleScope scope;
+    GPhoto2::Initialize(target);
+    GPCamera::Initialize(target);
   }
 
   NODE_MODULE(gphoto2, init);
 }
-
-

--- a/src/binding.h
+++ b/src/binding.h
@@ -1,97 +1,99 @@
-#ifndef __BINDING_H
-#define __BINDING_H
+/* Copyright 2012 Leonhardt Wille */
 
-#include <string>
+#ifndef SRC_BINDING_H_
+#define SRC_BINDING_H_
+
 extern "C" {
-#include <gphoto2/gphoto2-camera.h>
-#include <gphoto2/gphoto2-port-log.h>
+  #include <gphoto2/gphoto2-camera.h>
+  #include <gphoto2/gphoto2-port-log.h>
 }
-#include <cstdlib>
 #include <node.h>
 #include <node_buffer.h>
+#include <cstdlib>
 #include <string>
 #include <list>
 #include <map>
 
 #include "cvv8/v8-convert.hpp"
 
+#define ASYNC_FN(NAME) static void NAME(uv_work_t* req);
+#define ASYNC_CB(NAME) static void NAME(uv_work_t* req, int status);
 
-#define ASYNC_FN(NAME)\
-static void NAME(uv_work_t* req);
-
-#define ASYNC_CB(NAME)\
-static void NAME(uv_work_t* req, int status);
-
-#define DO_ASYNC(BATON,ASYNC,AFTER)\
-  uv_work_t* req = new uv_work_t();\
-  req->data = BATON;\
+#define DO_ASYNC(BATON, ASYNC, AFTER)                       \
+  uv_work_t* req = new uv_work_t();                         \
+  req->data = BATON;                                        \
   uv_queue_work(uv_default_loop(), req, ASYNC, AFTER);
 
-#define REQ_ARGS(N)                                                     \
-  if (args.Length() < (N))                                              \
-    return ThrowException(Exception::TypeError(                         \
-                             String::New("Expected " #N "arguments")));
+#define REQ_ARGS(N)                                         \
+  if (args.Length() < (N))                                  \
+    return ThrowException(Exception::TypeError(             \
+      String::New("Expected " #N "arguments")));
 
-#define ADD_PROTOTYPE_METHOD(class, name, method) \
-class ## _ ## name ## _symbol = NODE_PSYMBOL(#name); \
-NODE_SET_PROTOTYPE_METHOD(constructor_template, #name, method);
+#define ADD_PROTOTYPE_METHOD(class, name, method)                 \
+  class ## _ ## name ## _symbol = NODE_PSYMBOL(#name);            \
+  NODE_SET_PROTOTYPE_METHOD(constructor_template, #name, method);
 
-#define REQ_EXT_ARG(I, VAR) \
-if (args.Length() <= (I) || !args[I]->IsExternal()) \
-return ThrowException(Exception::TypeError( \
-String::New("Argument " #I " invalid"))); \
-Local<External> VAR = Local<External>::Cast(args[I]);
+#define REQ_EXT_ARG(I, VAR)                                 \
+  if (args.Length() <= (I) || !args[I]->IsExternal()) {     \
+    return ThrowException(Exception::TypeError(             \
+      String::New("Argument " #I " invalid")));             \
+  }                                                         \
+  Local<External> VAR = Local<External>::Cast(args[I]);
 
-#define REQ_FUN_ARG(I, VAR) \
-if (args.Length() <= (I) || !args[I]->IsFunction()) \
-return ThrowException(Exception::TypeError( \
-String::New("Argument " #I " must be a function"))); \
-Local<Function> VAR = Local<Function>::Cast(args[I]);
+#define REQ_FUN_ARG(I, VAR)                                 \
+  if (args.Length() <= (I) || !args[I]->IsFunction()) {     \
+    return ThrowException(Exception::TypeError(             \
+      String::New("Argument " #I " must be a function")));  \
+  }                                                         \
+  Local<Function> VAR = Local<Function>::Cast(args[I]);
 
-#define REQ_OBJ_ARG(I, VAR) \
-if (args.Length() <= (I) || !args[I]->IsObject()) \
-return ThrowException(Exception::TypeError( \
-String::New("Argument " #I " must be an Object"))); \
-Local<Array> VAR = Local<Array>::Cast(args[I]);
+#define REQ_OBJ_ARG(I, VAR)                                 \
+  if (args.Length() <= (I) || !args[I]->IsObject()) {       \
+    return ThrowException(Exception::TypeError(             \
+      String::New("Argument " #I " must be an Object")));   \
+  }                                                         \
+  Local<Array> VAR = Local<Array>::Cast(args[I]);
 
-#define REQ_ARR_ARG(I, VAR) \
-if (args.Length() <= (I) || !args[I]->IsArray()) \
-return ThrowException(Exception::TypeError( \
-String::New("Argument " #I " must be an Array"))); \
-Local<Array> VAR = Local<Array>::Cast(args[I]);
+#define REQ_ARR_ARG(I, VAR)                                 \
+  if (args.Length() <= (I) || !args[I]->IsArray()) {        \
+    return ThrowException(Exception::TypeError(             \
+      String::New("Argument " #I " must be an Array")));    \
+  }                                                         \
+  Local<Array> VAR = Local<Array>::Cast(args[I]);
 
+#define REQ_STR_ARG(I, VAR)                                 \
+  if (args.Length() <= (I) || !args[I]->IsString()) {       \
+    return ThrowException(Exception::TypeError(             \
+      String::New("Argument " #I " must be a string")));    \
+  }                                                         \
+  String::Utf8Value VAR(args[I]->ToString());
 
-#define REQ_STR_ARG(I, VAR) \
-if (args.Length() <= (I) || !args[I]->IsString()) \
-return ThrowException(Exception::TypeError( \
-String::New("Argument " #I " must be a string"))); \
-String::Utf8Value VAR(args[I]->ToString());
-
-#define REQ_INT_ARG(I, VAR)                                             \
-  if (args.Length() <= (I) || !args[I]->IsInt32())                      \
-    return ThrowException(Exception::TypeError(                         \
-                  String::New("Argument " #I " must be an integer")));  \
+#define REQ_INT_ARG(I, VAR)                                 \
+  if (args.Length() <= (I) || !args[I]->IsInt32()) {        \
+    return ThrowException(Exception::TypeError(             \
+      String::New("Argument " #I " must be an integer")));  \
+  }                                                         \
   int VAR = args[I]->Int32Value();
 
-#define RETURN_ON_ERROR(REQ, FNAME, ARGS, CLEANUP)\
-REQ->ret = FNAME ARGS;\
-if(REQ->ret < GP_OK){\
-  printf(#FNAME"=%d\n", REQ->ret);\
-  CLEANUP;\
-  return;\
-}
-
-
+#define RETURN_ON_ERROR(REQ, FNAME, ARGS, CLEANUP)          \
+  REQ->ret = FNAME ARGS;                                    \
+  if (REQ->ret < GP_OK) {                                   \
+    printf(#FNAME"=%d\n", REQ->ret);                        \
+    CLEANUP;                                                \
+    return;                                                 \
+  }
 
 #define V8STR(str) String::New(str)
 #define V8STR2(str, len) String::New(str, len)
 
-
 // Useful functions taken from library examples, with slight modifications
-int open_camera (Camera ** camera, std::string model, std::string port, GPPortInfoList *portinfolist, CameraAbilitiesList	*abilities);
-int  autodetect (CameraList *list, GPContext *context, GPPortInfoList **portinfolist, CameraAbilitiesList	**abilities);
-int  set_config_value_string (Camera *camera, const char *key, const char *val, GPContext *context);
-int  get_config_value_string (Camera *camera, const char *key, char **str, GPContext *context);
+int open_camera(Camera **camera, std::string model, std::string port,
+                GPPortInfoList *portinfolist, CameraAbilitiesList *abilities);
+int autodetect(CameraList *list, GPContext *context,
+               GPPortInfoList **portinfolist, CameraAbilitiesList  **abilities);
+int set_config_value_string(Camera *camera, const char *key, const char *val,
+                            GPContext *context);
+int get_config_value_string(Camera *camera, const char *key, char **str,
+                            GPContext *context);
 
-
-#endif
+#endif  // SRC_BINDING_H_

--- a/src/camera.cc
+++ b/src/camera.cc
@@ -1,21 +1,30 @@
-#include "camera.h"
-#include <sstream>
+/* Copyright 2012 Leonhardt Wille */
+
 #include <gphoto2/gphoto2-widget.h>
+#include <sstream>
+#include <string>
+#include "camera.h"  // NOLINT 
 
-using namespace v8;
-using namespace node;
-
+using std::string;
+using namespace node;  // NOLINT
+using namespace v8;  // NOLINT
 
 Persistent<FunctionTemplate> GPCamera::constructor_template;
 
-GPCamera::GPCamera(Handle<External> js_gphoto, std::string model, std::string port) : ObjectWrap(), model_(model), port_(port), camera_(NULL), config_(NULL){
+GPCamera::GPCamera(Handle<External> js_gphoto, string model, string port)
+    : ObjectWrap(),
+      model_(model),
+      port_(port),
+      camera_(NULL),
+      config_(NULL) {
   HandleScope scope;
-  GPhoto2 *gphoto = static_cast<GPhoto2*>(js_gphoto->Value());
+  GPhoto2 *gphoto = static_cast<GPhoto2 *>(js_gphoto->Value());
   this->gphoto = Persistent<External>::New(js_gphoto);
   this->gphoto_ = gphoto;
   uv_mutex_init(&this->cameraMutex);
 }
-GPCamera::~GPCamera(){
+
+GPCamera::~GPCamera() {
   printf("Camera destructor\n");
   this->gphoto_->closeCamera(this);
   this->gphoto.Dispose();
@@ -24,33 +33,29 @@ GPCamera::~GPCamera(){
   uv_mutex_destroy(&this->cameraMutex);
 }
 
-void
-GPCamera::Initialize(Handle<Object> target) {
-    HandleScope scope;
-    Local<FunctionTemplate> t = FunctionTemplate::New(New);
+void GPCamera::Initialize(Handle<Object> target) {
+  HandleScope scope;
+  Local<FunctionTemplate> t = FunctionTemplate::New(New);
 
-    // Constructor
-    constructor_template = Persistent<FunctionTemplate>::New(t);
+  // Constructor
+  constructor_template = Persistent<FunctionTemplate>::New(t);
+  constructor_template->InstanceTemplate()->SetInternalFieldCount(1);
+  constructor_template->SetClassName(String::NewSymbol("Camera"));
 
-
-    constructor_template->InstanceTemplate()->SetInternalFieldCount(1);
-    constructor_template->SetClassName(String::NewSymbol("Camera"));
-
-    ADD_PROTOTYPE_METHOD(camera, getConfig, GetConfig);
-    ADD_PROTOTYPE_METHOD(camera, setConfigValue, SetConfigValue);
-    ADD_PROTOTYPE_METHOD(camera, takePicture, TakePicture);
-    ADD_PROTOTYPE_METHOD(camera, downloadPicture, DownloadPicture);
-    target->Set(String::NewSymbol("Camera"), constructor_template->GetFunction());
+  ADD_PROTOTYPE_METHOD(camera, getConfig, GetConfig);
+  ADD_PROTOTYPE_METHOD(camera, setConfigValue, SetConfigValue);
+  ADD_PROTOTYPE_METHOD(camera, takePicture, TakePicture);
+  ADD_PROTOTYPE_METHOD(camera, downloadPicture, DownloadPicture);
+  target->Set(String::NewSymbol("Camera"), constructor_template->GetFunction());
 }
 
-Handle<Value>
-GPCamera::TakePicture(const Arguments& args) {
+Handle<Value> GPCamera::TakePicture(const Arguments& args) {
   HandleScope scope;
   GPCamera *camera = ObjectWrap::Unwrap<GPCamera>(args.This());
   camera->Ref();
   take_picture_request *picture_req;
 
-  if(args.Length() >= 2){
+  if (args.Length() >= 2) {
     REQ_OBJ_ARG(0, options);
     REQ_FUN_ARG(1, cb);
     picture_req = new take_picture_request();
@@ -60,21 +65,21 @@ GPCamera::TakePicture(const Arguments& args) {
     Local<Value> target = options->Get(String::New("targetPath"));
     Local<Value> preview = options->Get(String::New("preview"));
     Local<Value> socket  = options->Get(String::New("socket"));
-    if(target->IsString()){
-      picture_req->target_path = cv::CastFromJS<std::string>(target);
+    if (target->IsString()) {
+      picture_req->target_path = cv::CastFromJS<string>(target);
       picture_req->download = true;
     }
-    if(socket->IsString()){
-      picture_req->socket_path = cv::CastFromJS<std::string>(socket);
+    if (socket->IsString()) {
+      picture_req->socket_path = cv::CastFromJS<string>(socket);
       picture_req->download = true;
     }
-    if(dl->IsBoolean()){
+    if (dl->IsBoolean()) {
       picture_req->download = dl->ToBoolean()->Value();
     }
-    if(preview->IsBoolean()){
+    if (preview->IsBoolean()) {
       picture_req->preview = preview->ToBoolean()->Value();
     }
-  }else{
+  } else {
     REQ_FUN_ARG(0, cb);
     picture_req = new take_picture_request();
     picture_req->preview = false;
@@ -89,64 +94,61 @@ GPCamera::TakePicture(const Arguments& args) {
   return Undefined();
 }
 
-void
-GPCamera::Async_Capture(uv_work_t *_req){
+void GPCamera::Async_Capture(uv_work_t *_req) {
   take_picture_request *req = static_cast<take_picture_request *>(_req->data);
   req->cameraObject->lock();
-  if(req->preview){
+  if (req->preview) {
     capturePreview(req);
-  }else{
+  } else {
     takePicture(req);
   }
   req->cameraObject->unlock();
 }
 
-void GPCamera::Async_CaptureCb(uv_work_t *req, int status){
+void GPCamera::Async_CaptureCb(uv_work_t *req, int status) {
   HandleScope scope;
-  take_picture_request *capture_req = static_cast<take_picture_request*>(req->data);
+  take_picture_request *capture_req =
+    static_cast<take_picture_request *>(req->data);
 
   Handle<Value> argv[2];
   int argc = 1;
   argv[0] = Undefined();
-  if(capture_req->ret != GP_OK){
+  if (capture_req->ret != GP_OK) {
     argv[0] = Integer::New(capture_req->ret);
-  }
-  else if(capture_req->download && !capture_req->target_path.empty()){
-    argc=2;
+  } else if (capture_req->download && !capture_req->target_path.empty()) {
+    argc = 2;
     argv[1] = String::New(capture_req->target_path.c_str());
-  }
-  else if(capture_req->data && capture_req->download) {
+  } else if (capture_req->data && capture_req->download) {
     argc = 2;
     Local<Object> globalObj = Context::GetCurrent()->Global();
-    Local<Function> bufferConstructor = Local<Function>::Cast(globalObj->Get(String::New("Buffer")));
+    Local<Function> bufferConstructor =
+      Local<Function>::Cast(globalObj->Get(String::New("Buffer")));
     Handle<Value> constructorArgs[1];
     constructorArgs[0] = capture_req->length
       ? Integer::New(capture_req->length)
       : Integer::New(0);
     Local<Object> buffer = bufferConstructor->NewInstance(1, constructorArgs);
-    if(capture_req->length){
+    if (capture_req->length) {
       memmove(Buffer::Data(buffer), capture_req->data, capture_req->length);
       delete capture_req->data;
     }
     argv[1] = buffer;
-  }else{
+  } else {
     argc = 2;
     argv[1] = cv::CastToJS(capture_req->path);
   }
 
   capture_req->cb->Call(Context::GetCurrent()->Global(), argc, argv);
   capture_req->cb.Dispose();
-  if(capture_req->ret == GP_OK)  gp_file_free(capture_req->file);
+  if (capture_req->ret == GP_OK) gp_file_free(capture_req->file);
   capture_req->cameraObject->Unref();
   gp_context_unref(capture_req->context);
-//  gp_camera_unref(capture_req->camera);
-
+  // gp_camera_unref(capture_req->camera);
   delete capture_req;
 }
 
 
-Handle<Value>
-GPCamera::DownloadPicture(const Arguments& args){
+Handle<Value> GPCamera::DownloadPicture(const Arguments& args) {
   HandleScope scope;
 
   REQ_OBJ_ARG(0, options);
@@ -155,8 +157,8 @@ GPCamera::DownloadPicture(const Arguments& args){
   GPCamera *camera = ObjectWrap::Unwrap<GPCamera>(args.This());
   camera->Ref();
   take_picture_request *picture_req = new take_picture_request();
-  picture_req->cb = Persistent<Function>::New(cb);
 
+  picture_req->cb = Persistent<Function>::New(cb);
   picture_req->camera = camera->getCamera();
   picture_req->cameraObject = camera;
   picture_req->context = gp_context_new();
@@ -164,29 +166,32 @@ GPCamera::DownloadPicture(const Arguments& args){
 
   Local<Value> source = options->Get(String::New("cameraPath"));
   Local<Value> target = options->Get(String::New("targetPath"));
-  if(target->IsString()){
-    picture_req->target_path = cv::CastFromJS<std::string>(target);
+  if (target->IsString()) {
+    picture_req->target_path = cv::CastFromJS<string>(target);
   }
 
-  picture_req->path     = cv::CastFromJS<std::string>(source);
+  picture_req->path     = cv::CastFromJS<string>(source);
   gp_camera_ref(picture_req->camera);
   DO_ASYNC(picture_req, Async_DownloadPicture, Async_CaptureCb);
   return Undefined();
 }
 
-void GPCamera::Async_DownloadPicture(uv_work_t *_req){
+void GPCamera::Async_DownloadPicture(uv_work_t *_req) {
   take_picture_request *req = static_cast<take_picture_request *>(_req->data);
 
   req->cameraObject->lock();
   downloadPicture(req);
   req->cameraObject->unlock();
 }
-// Return available configuration widgets as a list in the form
-//  /main/status/model
-//  /main/status/serialnumber
-//  etc.
-Handle<Value>
-GPCamera::GetConfig(const Arguments& args) {
+
+/**
+ * Return available configuration widgets as a list in the form
+ * /main/status/model
+ * /main/status/serialnumber
+ * etc.
+ */
+
+Handle<Value> GPCamera::GetConfig(const Arguments& args) {
   HandleScope scope;
   REQ_FUN_ARG(0, cb)
   GPCamera *camera = ObjectWrap::Unwrap<GPCamera>(args.This());
@@ -200,64 +205,62 @@ GPCamera::GetConfig(const Arguments& args) {
 
   DO_ASYNC(config_req, Async_GetConfig, Async_GetConfigCb);
 
-  //Async_custom(Async_GetConfig, Async_PRI_DEFAULT, Async_GetConfigCb, config_req);
-  //ev_ref(EV_DEFAULT_UC);
+  // Async_custom(Async_GetConfig, Async_PRI_DEFAULT, Async_GetConfigCb,
+  //                config_req);
+  // ev_ref(EV_DEFAULT_UC);
   return Undefined();
 }
 
 namespace cvv8 {
-  template<> struct NativeToJS<TreeNode>
-    {
-      v8::Handle<v8::Value> operator()( TreeNode const & node ) const
-      {
-        HandleScope scope;
-        if(node.value){
-          Handle<Value> value = GPCamera::getWidgetValue(node.context, node.value);
-          if(value->IsObject()){
-            Local<Object> obj = value->ToObject();
-            if(node.subtree.size()){
-              obj->Set(cvv8::CastToJS("children"), cvv8::CastToJS(node.subtree));
-            }else{
-              obj->Set(cvv8::CastToJS("children"), Undefined());
-            }
+  template<> struct NativeToJS<TreeNode> {
+    v8::Handle<v8::Value> operator()(TreeNode const &node) const {
+      HandleScope scope;
+      if (node.value) {
+        Handle<Value> value = GPCamera::getWidgetValue(node.context,
+                                                       node.value);
+        if (value->IsObject()) {
+          Local<Object> obj = value->ToObject();
+          if (node.subtree.size()) {
+            obj->Set(cvv8::CastToJS("children"), cvv8::CastToJS(node.subtree));
+          } else {
+            obj->Set(cvv8::CastToJS("children"), Undefined());
           }
-          return scope.Close(value);
-        }else{
-          return scope.Close(Undefined());
         }
+        return scope.Close(value);
+      } else {
+        return scope.Close(Undefined());
       }
-    };
+    }
+  };
 }
 
-
-
-void GPCamera::Async_GetConfig(uv_work_t *req){
-  get_config_request *config_req = static_cast<get_config_request*>(req->data);
+void GPCamera::Async_GetConfig(uv_work_t *req) {
+  get_config_request *config_req = static_cast<get_config_request *>(req->data);
   int ret;
 
   config_req->cameraObject->lock();
-  ret = gp_camera_get_config(config_req->camera, &config_req->root, config_req->context);
+  ret = gp_camera_get_config(config_req->camera, &config_req->root,
+                             config_req->context);
   config_req->cameraObject->unlock();
 
-  if(ret < GP_OK){
+  if (ret < GP_OK) {
     config_req->ret = ret;
-  }else{
+  } else {
     ret = enumConfig(config_req, config_req->root, config_req->settings);
     config_req->ret = ret;
   }
 }
-void GPCamera::Async_GetConfigCb(uv_work_t *req, int status){
+
+void GPCamera::Async_GetConfigCb(uv_work_t *req, int status) {
   HandleScope scope;
-  get_config_request *config_req = static_cast<get_config_request*>(req->data);
+  get_config_request *config_req = static_cast<get_config_request *>(req->data);
 
   Handle<Value> argv[2];
 
-
-  if(config_req->ret == GP_OK){
+  if (config_req->ret == GP_OK) {
     argv[0] = Undefined();
     argv[1] = cv::CastToJS(config_req->settings);
-  }
-  else{
+  } else {
     argv[0] = cv::CastToJS(config_req->ret);
     argv[1] = Undefined();
   }
@@ -273,8 +276,7 @@ void GPCamera::Async_GetConfigCb(uv_work_t *req, int status){
   delete config_req;
 }
 
-Handle<Value>
-GPCamera::SetConfigValue(const Arguments& args) {
+Handle<Value> GPCamera::SetConfigValue(const Arguments &args) {
   HandleScope scope;
   GPCamera *camera = ObjectWrap::Unwrap<GPCamera>(args.This());
   camera->Ref();
@@ -284,23 +286,25 @@ GPCamera::SetConfigValue(const Arguments& args) {
   REQ_FUN_ARG(2, cb);
 
   set_config_request *config_req;
-  if(args[1]->IsString()){
+  if (args[1]->IsString()) {
     REQ_STR_ARG(1, value);
     config_req = new set_config_request();
     config_req->strValue = *value;
     config_req->valueType = set_config_request::String;
-  }else if(args[1]->IsInt32()){
+  } else if (args[1]->IsInt32()) {
     REQ_INT_ARG(1, value);
     config_req = new set_config_request();
     config_req->intValue = value;
     config_req->valueType = set_config_request::Integer;
-  }else if(args[1]->IsNumber()){
+  } else if (args[1]->IsNumber()) {
     double dblValue = args[1]->ToNumber()->Value();
     config_req = new set_config_request();
     config_req->fltValue = dblValue;
     config_req->valueType = set_config_request::Float;
-  }else{
-    return ThrowException(Exception::TypeError(String::New("Argument 1 invalid: String, Integer or Float value expected")));
+  } else {
+    return ThrowException(Exception::TypeError(
+      String::New("Argument 1 invalid: String, Integer or Float value "
+                  "expected")));
   }
   config_req->cameraObject = camera;
   config_req->camera = camera->getCamera();
@@ -313,22 +317,22 @@ GPCamera::SetConfigValue(const Arguments& args) {
 
   return Undefined();
 }
-void
-GPCamera::Async_SetConfigValue(uv_work_t *req){
+
+void GPCamera::Async_SetConfigValue(uv_work_t *req) {
   set_config_request *config_req = static_cast<set_config_request *>(req->data);
 
   config_req->cameraObject->lock();
   config_req->ret = setWidgetValue(config_req);
   config_req->cameraObject->unlock();
 }
-void
-GPCamera::Async_SetConfigValueCb(uv_work_t *req, int status){
+
+void GPCamera::Async_SetConfigValueCb(uv_work_t *req, int status) {
   HandleScope scope;
   set_config_request *config_req = static_cast<set_config_request *>(req->data);
 
   int argc = 0;
   Local<Value> argv[1];
-  if(config_req->ret < GP_OK){
+  if (config_req->ret < GP_OK) {
     argv[0] = Integer::New(config_req->ret);
     argc = 1;
   }
@@ -338,38 +342,39 @@ GPCamera::Async_SetConfigValueCb(uv_work_t *req, int status){
   gp_context_unref(config_req->context);
   gp_camera_unref(config_req->camera);
   delete config_req;
-
 }
 
-Handle<Value>
-GPCamera::New(const Arguments& args) {
+Handle<Value> GPCamera::New(const Arguments& args) {
   HandleScope scope;
 
   REQ_EXT_ARG(0, js_gphoto);
   REQ_STR_ARG(1, model_);
   REQ_STR_ARG(2, port_);
 
-  GPCamera *camera = new GPCamera(js_gphoto, (std::string)*model_, (std::string)*port_);
+  GPCamera *camera = new GPCamera(js_gphoto, (string) *model_,
+                                  (string) *port_);
   camera->Wrap(args.This());
   Local<Object> This = args.This();
-  This->Set(String::New("model"),String::New(camera->model_.c_str()));
-  This->Set(String::New("port"),String::New(camera->port_.c_str()));
+  This->Set(String::New("model"), String::New(camera->model_.c_str()));
+  This->Set(String::New("port"), String::New(camera->port_.c_str()));
   return args.This();
 }
 
-Camera* GPCamera::getCamera(){
-    //printf("getCamera %s gphoto=%p\n", this->isOpen() ? "open" : "closed", gp);
-  if(!this->isOpen()){
+Camera* GPCamera::getCamera() {
+  // printf("getCamera %s gphoto=%p\n", this->isOpen() ? "open" : "closed", gp);
+  if (!this->isOpen()) {
     this->gphoto_->openCamera(this);
   }
   return this->camera_;
 };
 
-bool
-GPCamera::close(){
+bool GPCamera::close() {
   // this->gphoto_->Unref();
-  if(this->camera_)
-    return gp_camera_exit(this->camera_, this->gphoto_->getContext()) < GP_OK ? false : true;
-  else
+  if (this->camera_) {
+    return gp_camera_exit(this->camera_, this->gphoto_->getContext()) < GP_OK
+      ? false
+      : true;
+  } else {
     return true;
+  }
 }

--- a/src/camera.h
+++ b/src/camera.h
@@ -1,118 +1,148 @@
-#ifndef __CAMERA_H
-#define __CAMERA_H
-  #include "binding.h"
-  #include "gphoto.h"
-  namespace cv = cvv8;
+/* Copyright 2012 Leonhardt Wille */
 
-  // Class for templated typedef's
-  // Initialize as A<Typename>::Tree etc.
-  template <typename T>
-  class A {
+#ifndef SRC_CAMERA_H_
+#define SRC_CAMERA_H_
+
+#include <list>
+#include <map>
+#include <string>
+#include "binding.h"  // NOLINT
+#include "gphoto.h"  // NOLINT
+
+namespace cv = cvv8;
+
+/**
+ * Class for templated typedef's
+ * Initialize as A<Typename>::Tree etc.
+ */
+
+template <typename T> class A {
   private:
-    A(void) {};
+    A(void) {}
   public:
     typedef std::map<std::string, T> Tree;
-  };
+};
 
 
-  struct TreeNode{
-    CameraWidget* value;
+struct TreeNode {
+  CameraWidget* value;
+  GPContext *context;
+  A<TreeNode>::Tree subtree;
+  TreeNode(CameraWidget* value, GPContext *context)
+      : value(value), context(context) {}
+  TreeNode() : value(NULL), context(NULL) {}
+};
+
+using namespace v8;  // NOLINT
+typedef std::list<std::string> StringList;
+
+static Persistent<String> camera_getConfig_symbol;
+static Persistent<String> camera_getConfigValue_symbol;
+static Persistent<String> camera_setConfigValue_symbol;
+static Persistent<String> camera_takePicture_symbol;
+static Persistent<String> camera_downloadPicture_symbol;
+
+class GPCamera : public node::ObjectWrap {
+  uv_mutex_t cameraMutex;
+  void lock() {
+    uv_mutex_lock(&this->cameraMutex);
+  }
+  void unlock() {
+    uv_mutex_unlock(&this->cameraMutex);
+  }
+
+  std::string model_;
+  std::string port_;
+  Persistent<External> gphoto;
+  GPhoto2 *gphoto_;
+  Camera *camera_;
+  CameraWidget *config_;
+  bool isOpen() {
+    return this->camera_ ? true : false;
+  }
+
+  struct take_picture_request {
+    Persistent<Function> cb;
+    Camera *camera;
+    GPCamera *cameraObject;
+    CameraFile *file;
     GPContext *context;
-    A<TreeNode>::Tree subtree;
-    TreeNode(CameraWidget* value, GPContext *context) : value(value), context(context) {}
-    TreeNode() : value(NULL), context(NULL) {}
+    const char *data;
+    unsigned long int length;  // NOLINT
+    int ret;
+    bool download;
+    bool preview;
+    std::string path;
+    std::string target_path;
+    std::string socket_path;
   };
 
-  using namespace v8;
-  typedef std::list<std::string> StringList;
-
-  static Persistent<String> camera_getConfig_symbol;
-  static Persistent<String> camera_getConfigValue_symbol;
-  static Persistent<String> camera_setConfigValue_symbol;
-  static Persistent<String> camera_takePicture_symbol;
-  static Persistent<String> camera_downloadPicture_symbol;
-  class GPCamera : public node::ObjectWrap {
-    uv_mutex_t cameraMutex;
-    void lock(){uv_mutex_lock(&this->cameraMutex);};
-    void unlock(){uv_mutex_unlock(&this->cameraMutex);};
-
-    std::string model_;
-    std::string port_;
-    Persistent<External> gphoto;
-    GPhoto2    *gphoto_;
-    Camera     *camera_;
-  	CameraWidget *config_;
-    bool isOpen(){return this->camera_ ? true : false;};
-
-    struct take_picture_request {
-      Persistent<Function> cb;
-      Camera *camera;
-      GPCamera *cameraObject;
-      CameraFile *file;
-      GPContext *context;
-      const char *data;
-      unsigned long int length;
-      int ret;
-      bool download;
-      bool preview;
-      std::string path;
-      std::string target_path;
-      std::string socket_path;
-    };
-    struct get_config_request {
-      Persistent<Function> cb;
-      GPCamera  *cameraObject;
-      Camera    *camera;
-      GPContext *context;
-      CameraWidget *root;
-      int ret;
-      StringList keys;
-      A<TreeNode>::Tree settings;
-    };
-    struct set_config_request {
-      Persistent<Function> cb;
-      GPCamera  *cameraObject;
-      Camera    *camera;
-      GPContext *context;
-      std::string key;
-      enum {String,Float,Integer} valueType;
-      float fltValue;
-      int intValue;
-      std::string strValue;
-      int ret;
-    };
-    static int enumConfig(get_config_request* req, CameraWidget *root, A<TreeNode>::Tree &tree);
-    static int getConfigWidget(get_config_request *req, std::string name, CameraWidget **child, CameraWidget **rootconfig);
-    static int setWidgetValue(set_config_request *req);
-    static void takePicture(take_picture_request *req);
-    static void capturePreview(take_picture_request *req);
-    static void downloadPicture(take_picture_request *req);
-    static int getCameraFile(take_picture_request *req, CameraFile **file);
-    bool close();
-
-    public:
-      GPCamera(Handle<External> js_gphoto, std::string  model, std::string  port);
-      ~GPCamera();
-      static Handle<Value> getWidgetValue(GPContext *context, CameraWidget *widget);
-      static Persistent<FunctionTemplate> constructor_template;
-      static void Initialize(Handle<Object> target);
-      static Handle<Value> New(const Arguments& args);
-      static Handle<Value> GetConfig(const Arguments& args);
-      static Handle<Value> GetConfigValue(const Arguments &args);
-      static Handle<Value> SetConfigValue(const Arguments &args);
-      static Handle<Value> TakePicture(const Arguments &args);
-      static Handle<Value> DownloadPicture(const Arguments& args);
-      ASYNC_FN(Async_GetConfig);
-      ASYNC_CB(Async_GetConfigCb);
-      ASYNC_FN(Async_SetConfigValue);
-      ASYNC_CB(Async_SetConfigValueCb);
-      ASYNC_FN(Async_DownloadPicture);
-      ASYNC_FN(Async_Capture);
-      ASYNC_CB(Async_CaptureCb);
-      std::string getPort(){return this->port_;};
-      std::string getModel(){return this->model_;};
-      void setCamera(Camera *camera){this->camera_=camera;};
-      Camera* getCamera();
+  struct get_config_request {
+    Persistent<Function> cb;
+    GPCamera  *cameraObject;
+    Camera    *camera;
+    GPContext *context;
+    CameraWidget *root;
+    int ret;
+    StringList keys;
+    A<TreeNode>::Tree settings;
   };
 
-#endif
+  struct set_config_request {
+    Persistent<Function> cb;
+    GPCamera  *cameraObject;
+    Camera    *camera;
+    GPContext *context;
+    std::string key;
+    enum {String, Float, Integer} valueType;
+    float fltValue;
+    int intValue;
+    std::string strValue;
+    int ret;
+  };
+
+  static int enumConfig(get_config_request* req, CameraWidget *root,
+                        A<TreeNode>::Tree &tree);
+  static int getConfigWidget(get_config_request *req, std::string name,
+                             CameraWidget **child, CameraWidget **rootconfig);
+  static int setWidgetValue(set_config_request *req);
+  static void takePicture(take_picture_request *req);
+  static void capturePreview(take_picture_request *req);
+  static void downloadPicture(take_picture_request *req);
+  static int getCameraFile(take_picture_request *req, CameraFile **file);
+
+  bool close();
+
+  public:
+    GPCamera(Handle<External> js_gphoto, std::string  model, std::string  port);
+    ~GPCamera();
+    static Handle<Value> getWidgetValue(GPContext *context,
+                                        CameraWidget *widget);
+    static Persistent<FunctionTemplate> constructor_template;
+    static void Initialize(Handle<Object> target);
+    static Handle<Value> New(const Arguments& args);
+    static Handle<Value> GetConfig(const Arguments& args);
+    static Handle<Value> GetConfigValue(const Arguments &args);
+    static Handle<Value> SetConfigValue(const Arguments &args);
+    static Handle<Value> TakePicture(const Arguments &args);
+    static Handle<Value> DownloadPicture(const Arguments& args);
+    ASYNC_FN(Async_GetConfig);
+    ASYNC_CB(Async_GetConfigCb);
+    ASYNC_FN(Async_SetConfigValue);
+    ASYNC_CB(Async_SetConfigValueCb);
+    ASYNC_FN(Async_DownloadPicture);
+    ASYNC_FN(Async_Capture);
+    ASYNC_CB(Async_CaptureCb);
+    std::string getPort() {
+      return this->port_;
+    }
+    std::string getModel() {
+      return this->model_;
+    }
+    void setCamera(Camera *camera) {
+      this->camera_ = camera;
+    }
+    Camera* getCamera();
+};
+
+#endif  // SRC_CAMERA_H_

--- a/src/camera_helpers.cc
+++ b/src/camera_helpers.cc
@@ -1,167 +1,175 @@
-#include "camera.h"
+/* Copyright 2012 Leonhardt Wille */
+
+#include <errno.h>
+#include <sys/socket.h>
+#include <sys/types.h>
+#include <sys/un.h>
+#include <unistd.h>
+#include <cstring>
 #include <ctime>
 #include <sstream>
-#include <cstring>
-#include <errno.h>
-#include <unistd.h>
-#include <sys/types.h>
-#include <sys/socket.h>
-#include <sys/un.h>
+#include <string>
+#include "camera.h"  // NOLINT
+
 namespace cv = cvv8;
 
 namespace cvv8 {
-    template<> struct NativeToJS<float> : NativeToJS<double> {};
+  template<> struct NativeToJS<float> : NativeToJS<double> {};
 }
 
-Handle<Value> GPCamera::getWidgetValue(GPContext *context, CameraWidget *widget) {
+Handle<Value> GPCamera::getWidgetValue(GPContext *context,
+                                       CameraWidget *widget) {
   HandleScope scope;
-	const char *label;
-	CameraWidgetType	type;
+  const char *label;
+  CameraWidgetType  type;
   int ret;
   Local<Object> value = Object::New();
 
-	ret = gp_widget_get_type (widget, &type);
-	if (ret != GP_OK)
-		return Undefined();
-	ret = gp_widget_get_label (widget, &label);
-	if (ret != GP_OK)
-		return Undefined();
+  ret = gp_widget_get_type(widget, &type);
+  if (ret != GP_OK) return Undefined();
+  ret = gp_widget_get_label(widget, &label);
+  if (ret != GP_OK) return Undefined();
   value->Set(cv::CastToJS("label"), cv::CastToJS(label));
   value->Set(cv::CastToJS("type"), Undefined());
-//	printf ("Label: %s\n", label); /* "Label:" is not i18ned, the "label" variable is */
-	switch (type) {
-	case GP_WIDGET_TEXT: {		/* char *		*/
-		char *txt;
-		ret = gp_widget_get_value (widget, &txt);
-		if (ret == GP_OK) {
-      value->Set(cv::CastToJS("type"), cv::CastToJS("string"));
-      value->Set(cv::CastToJS("value"), cv::CastToJS(txt));
-		} else {
-			gp_context_error (context, "Failed to retrieve value of text widget %s.", label);
-		}
-		break;
-	}
-	case GP_WIDGET_RANGE: {	/* float		*/
-		float	f, max,min,step;
-
-		ret = gp_widget_get_range (widget, &min, &max, &step);
-		if (ret == GP_OK)
-			ret = gp_widget_get_value (widget, &f);
-		if (ret == GP_OK) {
-		  value->Set(cv::CastToJS("type"), cv::CastToJS("range"));
-      value->Set(cv::CastToJS("value"), cv::CastToJS(f));
-      value->Set(cv::CastToJS("max"), cv::CastToJS(max));
-      value->Set(cv::CastToJS("min"), cv::CastToJS(min));
-      value->Set(cv::CastToJS("step"), cv::CastToJS(step));
+  // printf("Label: %s\n", label);
+  // "Label:" is not i18ned, the "label" variable is
+  switch (type) {
+    case GP_WIDGET_TEXT: { /* char * */
+      char *txt;
+      ret = gp_widget_get_value(widget, &txt);
+      if (ret == GP_OK) {
+        value->Set(cv::CastToJS("type"), cv::CastToJS("string"));
+        value->Set(cv::CastToJS("value"), cv::CastToJS(txt));
+      } else {
+        gp_context_error(context,
+                         "Failed to retrieve value of text widget %s.",
+                         label);
+      }
       break;
-		} else {
-			gp_context_error (context, "Failed to retrieve values of range widget %s.", label);
-		}
-		break;
-	}
-	case GP_WIDGET_TOGGLE: {	/* int		*/
-		int	t;
-		ret = gp_widget_get_value (widget, &t);
-		if (ret == GP_OK) {
-		  value->Set(cv::CastToJS("type"), cv::CastToJS("toggle"));
-      value->Set(cv::CastToJS("value"), cv::CastToJS(t));
+    }
+    case GP_WIDGET_RANGE: { /* float */
+      float f, max, min, step;
+
+      ret = gp_widget_get_range(widget, &min, &max, &step);
+      if (ret == GP_OK) {
+        ret = gp_widget_get_value(widget, &f);
+        value->Set(cv::CastToJS("type"), cv::CastToJS("range"));
+        value->Set(cv::CastToJS("value"), cv::CastToJS(f));
+        value->Set(cv::CastToJS("max"), cv::CastToJS(max));
+        value->Set(cv::CastToJS("min"), cv::CastToJS(min));
+        value->Set(cv::CastToJS("step"), cv::CastToJS(step));
+      } else {
+        gp_context_error(context,
+                         "Failed to retrieve values of range widget %s.",
+                         label);
+      }
       break;
-		} else {
-			gp_context_error (context, "Failed to retrieve values of toggle widget %s.", label);
-		}
-		break;
-	}
-	case GP_WIDGET_DATE:  {		/* int			*/
-		int	t;
+    }
+    case GP_WIDGET_TOGGLE: { /* int */
+      int t;
+      ret = gp_widget_get_value(widget, &t);
+      if (ret == GP_OK) {
+        value->Set(cv::CastToJS("type"), cv::CastToJS("toggle"));
+        value->Set(cv::CastToJS("value"), cv::CastToJS(t));
+      } else {
+        gp_context_error(context,
+                         "Failed to retrieve values of toggle widget %s.",
+                         label);
+      }
+      break;
+    }
+    case GP_WIDGET_DATE:  { /* int */
+      int t;
+      ret = gp_widget_get_value(widget, &t);
+      if (ret != GP_OK) {
+        gp_context_error(context,
+                         "Failed to retrieve values of date/time widget %s.",
+                         label);
+        break;
+      }
+      value->Set(cv::CastToJS("type"), cv::CastToJS("date"));
+      value->Set(cv::CastToJS("value"), Date::New(t * 1000.0));
+      break;
+    }
+    case GP_WIDGET_MENU:
+    case GP_WIDGET_RADIO: { /* char * */
+      int cnt, i;
+      const char *current = NULL;
 
-		ret = gp_widget_get_value (widget, &t);
-		if (ret != GP_OK) {
-			gp_context_error (context, "Failed to retrieve values of date/time widget %s.", label);
-			break;
-		}
-	  value->Set(cv::CastToJS("type"), cv::CastToJS("date"));
-    value->Set(cv::CastToJS("value"), Date::New(t*1000.0));
-    break;
-	}
-	case GP_WIDGET_MENU:
-	case GP_WIDGET_RADIO: { /* char *		*/
-    int cnt, i;
-    const char *current = NULL;
+      ret = gp_widget_get_value(widget, &current);
+      cnt = gp_widget_count_choices(widget);
+      if (cnt < GP_OK) {
+        ret = cnt;
+        break;
+      }
+      ret = GP_ERROR_BAD_PARAMETERS;
 
+      Local<Array> choices = Array::New(cnt);
+      for (i = 0; i < cnt; i++) {
+        const char *choice = NULL;
 
-    ret = gp_widget_get_value (widget, &current);
+        ret = gp_widget_get_choice(widget, i, &choice);
+        if (ret != GP_OK) continue;
+        choices->Set(cv::CastToJS(i), cv::CastToJS(choice));
+      }
 
-
-		cnt = gp_widget_count_choices (widget);
-		if (cnt < GP_OK) {
-			ret = cnt;
-			break;
-		}
-		ret = GP_ERROR_BAD_PARAMETERS;
-
-    Local<Array> choices = Array::New(cnt);
-		for ( i=0; i<cnt; i++) {
-			const char *choice = NULL;
-
-			ret = gp_widget_get_choice (widget, i, &choice);
-			if (ret != GP_OK)
-				continue;
-      choices->Set(cv::CastToJS(i), cv::CastToJS(choice));
-		}
-
-	  value->Set(cv::CastToJS("type"), cv::CastToJS("choice"));
-    value->Set(cv::CastToJS("value"), cv::CastToJS(current));
-    value->Set(cv::CastToJS("choices"), choices);
-		break;
-	}
-
-	/* ignore: */
-	case GP_WIDGET_WINDOW:
-    value->Set(cv::CastToJS("type"), cv::CastToJS("window"));
-    break;
-	case GP_WIDGET_SECTION:
-    value->Set(cv::CastToJS("type"), cv::CastToJS("section"));
-  break;
-	case GP_WIDGET_BUTTON:
-    value->Set(cv::CastToJS("type"), cv::CastToJS("button"));
-		break;
-	}
+      value->Set(cv::CastToJS("type"), cv::CastToJS("choice"));
+      value->Set(cv::CastToJS("value"), cv::CastToJS(current));
+      value->Set(cv::CastToJS("choices"), choices);
+      break;
+    }
+    /* ignore: */
+    case GP_WIDGET_WINDOW: {
+      value->Set(cv::CastToJS("type"), cv::CastToJS("window"));
+      break;
+    }
+    case GP_WIDGET_SECTION: {
+      value->Set(cv::CastToJS("type"), cv::CastToJS("section"));
+      break;
+    }
+    case GP_WIDGET_BUTTON: {
+      value->Set(cv::CastToJS("type"), cv::CastToJS("button"));
+    }
+  }
   return scope.Close(value);
 }
 
-int GPCamera::setWidgetValue(set_config_request *req){
+int GPCamera::setWidgetValue(set_config_request *req) {
   int ret;
   CameraWidget *child;
   CameraWidget *rootconfig;
   ret = gp_camera_get_config(req->camera, &rootconfig, req->context);
-  if(ret < GP_OK) return ret;
+  if (ret < GP_OK) return ret;
 
   ret = gp_widget_get_child_by_name(rootconfig, req->key.c_str(), &child);
-  if(ret < GP_OK) return ret;
+  if (ret < GP_OK) return ret;
 
-  switch(req->valueType){
-    case set_config_request::String :
+  switch (req->valueType) {
+    case set_config_request::String: {
       ret = gp_widget_set_value(child, req->strValue.c_str());
-    break;
-    case set_config_request::Integer :
+      break;
+    }
+    case set_config_request::Integer: {
       ret = gp_widget_set_value(child, &req->intValue);
-    break;
-    case set_config_request::Float :
+      break;
+    }
+    case set_config_request::Float: {
       ret = gp_widget_set_value(child, &req->fltValue);
-    break;
+    }
   }
-  if(ret < GP_OK) return ret;
+  if (ret < GP_OK) return ret;
 
-  ret = gp_camera_set_config (req->camera, rootconfig, req->context);
-  if(ret < GP_OK) return ret;
+  ret = gp_camera_set_config(req->camera, rootconfig, req->context);
+  if (ret < GP_OK) return ret;
   gp_widget_free(rootconfig);
   return ret;
 }
 
-int GPCamera::getConfigWidget(get_config_request *req, std::string name, CameraWidget **child, CameraWidget **rootconfig){
+int GPCamera::getConfigWidget(get_config_request *req, std::string name,
+                              CameraWidget **child, CameraWidget **rootconfig) {
   int ret;
   GPContext *context = req->context;
-  Camera    *camera  = req->camera;
+  Camera *camera = req->camera;
 
   gp_camera_get_config(camera, rootconfig, context);
   ret = gp_widget_get_child_by_name(*rootconfig, name.c_str(), child);
@@ -169,193 +177,199 @@ int GPCamera::getConfigWidget(get_config_request *req, std::string name, CameraW
   // name not found --> path specified
   // recurse until the specified child is found
   if (ret != GP_OK) {
-		char		*part, *s, *newname;
+    char *part, *s, *newname;
 
-		newname = strdup(name.c_str());
-		if (!newname)
-			return GP_ERROR_NO_MEMORY;
-		*child = *rootconfig;
-		part = newname;
-		while (part[0] == '/')
-			part++;
-			while (1) {
-  			CameraWidget *tmp;
-
-  			s = strchr (part,'/');
-  			if (s)
-  				*s='\0';
-  			ret = gp_widget_get_child_by_name (*child, part, &tmp);
-  			if (ret != GP_OK)
-  				ret = gp_widget_get_child_by_label (*child, part, &tmp);
-  			if (ret != GP_OK)
-  				break;
-  			*child = tmp;
-  			if (!s) /* end of path */
-  				break;
-  			part = s+1;
-  			while (part[0] == '/')
-  				part++;
-  		}
-  		if (s) { /* if we have stuff left over, we failed */
-  			gp_context_error (context, "%s not found in configuration tree.", newname);
-  			free (newname);
-  			gp_widget_free (*rootconfig);
-  			return GP_ERROR;
-  		}
-  		free (newname);
-  	}
-  	return GP_OK;
+    newname = strdup(name.c_str());
+    if (!newname) return GP_ERROR_NO_MEMORY;
+    *child = *rootconfig;
+    part = newname;
+    while (part[0] == '/') {
+      part++;
+    }
+    while (1) {
+      CameraWidget *tmp;
+      s = strchr(part, '/');
+      if (s) {
+        *s = '\0';
+      }
+      ret = gp_widget_get_child_by_name(*child, part, &tmp);
+      if (ret != GP_OK) {
+        ret = gp_widget_get_child_by_label(*child, part, &tmp);
+      }
+      if (ret != GP_OK) {
+        break;
+      }
+      *child = tmp;
+      if (!s) { /* end of path */
+        break;
+      }
+      part = s + 1;
+      while (part[0] == '/') {
+        part++;
+      }
+    }
+    if (s) { /* if we have stuff left over, we failed */
+      gp_context_error(context, "%s not found in configuration tree.",
+                       newname);
+      free(newname);
+      gp_widget_free(*rootconfig);
+      return GP_ERROR;
+    }
+    free(newname);
+  }
+  return GP_OK;
 }
 
-int GPCamera::enumConfig(get_config_request* req, CameraWidget *root, A<TreeNode>::Tree &tree){
-  int ret,n,i;
-  char* label, *name, *uselabel;
+int GPCamera::enumConfig(get_config_request *req, CameraWidget *root,
+                         A<TreeNode>::Tree &tree) {
+  int ret, n, i;
+  char *label, *name, *uselabel;
 
-  gp_widget_get_label (root,(const char**)&label);
-  ret = gp_widget_get_name (root, (const char**)&name);
+  gp_widget_get_label(root, (const char**) &label);
+  ret = gp_widget_get_name(root, (const char**) &name);
 
-	TreeNode node(root, req->context);
-	if (std::string((const char*)name).length())
-		uselabel = name;
-	else
-		uselabel = label;
+  TreeNode node(root, req->context);
+  if (std::string((const char*) name).length()) {
+    uselabel = name;
+  } else {
+    uselabel = label;
+  }
 
-	n = gp_widget_count_children(root);
-	for (i=0; i<n; i++) {
-		CameraWidget *child;
-		ret = gp_widget_get_child(root, i, &child);
-		if (ret != GP_OK)
-			continue;
-		enumConfig(req, child, node.subtree);
-	}
+  n = gp_widget_count_children(root);
+  for (i = 0; i < n; i++) {
+    CameraWidget *child;
+    ret = gp_widget_get_child(root, i, &child);
+    if (ret != GP_OK) continue;
+    enumConfig(req, child, node.subtree);
+  }
   tree[uselabel] = node;
   return GP_OK;
 }
 
-int
-GPCamera::getCameraFile(take_picture_request *req, CameraFile **file){
+int GPCamera::getCameraFile(take_picture_request *req, CameraFile **file) {
   int retval = GP_OK;
   int fd;
-  if(!req->target_path.empty()){
-	  char *tmpname = strdup(req->target_path.c_str());
-	  fd = mkstemp(tmpname);
+  if (!req->target_path.empty()) {
+    char *tmpname = strdup(req->target_path.c_str());
+    fd = mkstemp(tmpname);
     req->target_path = tmpname;
-  }else if(!req->socket_path.empty()){
-    struct sockaddr_un  serv_addr;
-    bzero((char *)&serv_addr,sizeof(serv_addr));
+  } else if (!req->socket_path.empty()) {
+    struct sockaddr_un serv_addr;
+    bzero(&serv_addr, sizeof(serv_addr));
     serv_addr.sun_family = AF_UNIX;
-    strcpy(serv_addr.sun_path, "/tmp/preview.sock");// req->socket_path.c_str());
+    // req->socket_path.c_str();
+    snprintf(serv_addr.sun_path, sizeof(serv_addr.sun_path),
+              "/tmp/preview.sock");
 
-    if ((fd = socket(AF_UNIX, SOCK_STREAM,0)) < 0)
+    if ((fd = socket(AF_UNIX, SOCK_STREAM, 0)) < 0) {
       perror("Creating socket");
-
-    if (connect(fd, (struct sockaddr *) &serv_addr, sizeof(serv_addr)) < 0){
+    }
+    if (connect(fd, (struct sockaddr *) &serv_addr, sizeof(serv_addr)) < 0) {
       perror(serv_addr.sun_path);
     }
-  }else{
+  } else {
     return gp_file_new(file);
   }
 
   if (fd == -1) {
-	    if (errno == EACCES) {
-	        gp_context_error (req->context, "Permission denied");
-	    }
-      return errno;
-	}
-  if(fd>=0){
-  	retval = gp_file_new_from_fd(file, fd);
-  	if (retval != GP_OK) {
-  		::close(fd);
-		}
-	}
+    if (errno == EACCES) gp_context_error(req->context, "Permission denied");
+    return errno;
+  }
+  if (fd >= 0) {
+    retval = gp_file_new_from_fd(file, fd);
+    if (retval != GP_OK) ::close(fd);
+  }
   return retval;
 }
 
-void
-GPCamera::downloadPicture(take_picture_request *req){
-	CameraFile *file;
+void GPCamera::downloadPicture(take_picture_request *req) {
+  CameraFile *file;
   const char *data;
+  char *component;
+  char *saveptr;
   int retval;
   std::ostringstream folder;
   std::string name;
 
-  char *component = strtok((char*)req->path.c_str(),"/");
-  while(component){
-    char *next =strtok(NULL, "/");
-    if(next)
+  component = strtok_r(const_cast<char *>(req->path.c_str()), "/", &saveptr);
+  while (component) {
+    char *next = strtok_r(NULL, "/", &saveptr);
+    if (next) {
       folder << "/" << component;
-    else
+    } else {
       name = component;
+    }
     component = next;
   }
-  if(folder.str().length() == 0)
-    folder<<"/";
+  if (folder.str().length() == 0) folder << "/";
 
   retval = getCameraFile(req, &file);
 
   if (retval == GP_OK) {
-	  retval = gp_camera_file_get(req->camera, folder.str().c_str(), name.c_str(), GP_FILE_TYPE_NORMAL, file, req->context);
+    retval = gp_camera_file_get(req->camera, folder.str().c_str(), name.c_str(),
+                                GP_FILE_TYPE_NORMAL, file, req->context);
   } else {
-    req->ret=retval;
+    req->ret = retval;
     return;
   }
 
-	// Fallback to downloading into buffer
-	if(retval == GP_OK && req->target_path.empty()){
-	  retval = gp_file_get_data_and_size(file, &data, &req->length);
+  /* Fallback to downloading into buffer */
+  if (retval == GP_OK && req->target_path.empty()) {
+    retval = gp_file_get_data_and_size(file, &data, &req->length);
     if (retval == GP_OK && req->length != 0) {
-      // `gp_file_free` will call `free` on `file->data` pointer. We need to save our data
+      /* `gp_file_free` will call `free` on `file->data` pointer, save data */
       req->data = new char[req->length];
       memmove(const_cast<char *>(req->data), data, req->length);
     }
     data = NULL;
-	}
+  }
 
-  if(retval == GP_OK){
-    retval = gp_camera_file_delete(req->camera, folder.str().c_str(), name.c_str(), req->context);
+  if (retval == GP_OK) {
+    retval = gp_camera_file_delete(req->camera, folder.str().c_str(),
+                                   name.c_str(), req->context);
   }
 
   gp_file_free(file);
-  req->ret=retval;
+  req->ret = retval;
 }
 
-void
-GPCamera::capturePreview(take_picture_request *req){
+void GPCamera::capturePreview(take_picture_request *req) {
   int retval;
   CameraFile *file;
 
   retval = getCameraFile(req, &file);
 
-  if(retval == GP_OK){
+  if (retval == GP_OK) {
     retval = gp_camera_capture_preview(req->camera, file, req->context);
   }
 
-  if(!(req->target_path.empty() || req->socket_path.empty())) {
+  if (!(req->target_path.empty() || req->socket_path.empty())) {
     gp_file_free(file);
   }
 
   req->ret = retval;
 }
 
-void
-GPCamera::takePicture(take_picture_request *req) {
-	int retval;
-	CameraFilePath camera_file_path;
+void GPCamera::takePicture(take_picture_request *req) {
+  int retval;
+  CameraFilePath camera_file_path;
 
-	/* NOP: This gets overridden in the library to /capt0000.jpg */
-	strcpy(camera_file_path.folder, "/");
-	strcpy(camera_file_path.name, "foo.jpg");
-	retval = gp_camera_capture(req->camera, GP_CAPTURE_IMAGE, &camera_file_path, req->context);
+  /* NOP: This gets overridden in the library to /capt0000.jpg */
+  snprintf(camera_file_path.folder, sizeof(camera_file_path.folder), "/");
+  snprintf(camera_file_path.name, sizeof(camera_file_path.name), "foo.jpg");
+  retval = gp_camera_capture(req->camera, GP_CAPTURE_IMAGE, &camera_file_path,
+                             req->context);
 
   std::ostringstream path;
-  if(std::string(camera_file_path.folder).compare("/") != 0)
+  if (std::string(camera_file_path.folder).compare("/") != 0) {
     path << camera_file_path.folder;
+  }
   path << "/";
   path << camera_file_path.name;
   req->path = path.str();
   req->ret = retval;
 
-  if(retval == GP_OK && req->download){
+  if (retval == GP_OK && req->download) {
     downloadPicture(req);
   }
 }

--- a/src/gphoto.cc
+++ b/src/gphoto.cc
@@ -1,25 +1,27 @@
-#include "gphoto.h"
-#include "camera.h"
+/* Copyright 2012 Leonhardt Wille */
 
-#include <string.h>
+#include <string>
+#include "camera.h"  // NOLINT
+#include "gphoto.h"  // NOLINT
+
 Persistent<FunctionTemplate> GPhoto2::constructor_template;
 
-static void onError (GPContext *context, const char *str, void *data) {
-  fprintf (stderr, "### %s\n", str);
+static void onError(GPContext *context, const char *str, void *data) {
+  fprintf(stderr, "### %s\n", str);
 }
 
-static void onStatus (GPContext *context, const char *str, void *data) {
-  fprintf (stderr, "### %s\n", str);
+static void onStatus(GPContext *context, const char *str, void *data) {
+  fprintf(stderr, "### %s\n", str);
 }
 
 GPhoto2::GPhoto2() : portinfolist_(NULL), abilities_(NULL) {
   this->context_ = gp_context_new();
-  gp_context_set_error_func (this->context_, onError, NULL);
-  gp_context_set_status_func (this->context_, onStatus, NULL);
-  gp_camera_new (&this->_camera);
+  gp_context_set_error_func(this->context_, onError, NULL);
+  gp_context_set_status_func(this->context_, onStatus, NULL);
+  gp_camera_new(&this->_camera);
 }
 
-GPhoto2::~GPhoto2(){
+GPhoto2::~GPhoto2() {
 }
 
 void GPhoto2::Initialize(Handle<Object> target) {
@@ -37,46 +39,44 @@ void GPhoto2::Initialize(Handle<Object> target) {
   ADD_PROTOTYPE_METHOD(gphoto, list, List);
   ADD_PROTOTYPE_METHOD(gphoto, onLog, SetLogHandler);
 
-  target->Set(String::NewSymbol("GPhoto2"), constructor_template->GetFunction());
+  target->Set(String::NewSymbol("GPhoto2"),
+              constructor_template->GetFunction());
 }
-
-
 
 Handle<Value> GPhoto2::New(const Arguments &args) {
-    HandleScope scope;
-    GPhoto2 *gphoto = new GPhoto2();
-    gphoto->Wrap(args.This());
-    return args.This();
+  HandleScope scope;
+  GPhoto2 *gphoto = new GPhoto2();
+  gphoto->Wrap(args.This());
+  return args.This();
 }
 
-Handle<Value> GPhoto2::Test(const Arguments &args){
+Handle<Value> GPhoto2::Test(const Arguments &args) {
   printf("(Test)Everything is fine\n");
   return Undefined();
 }
 
-Handle<Value> GPhoto2::List(const Arguments &args){
-    HandleScope scope;
+Handle<Value> GPhoto2::List(const Arguments &args) {
+  HandleScope scope;
 
-    REQ_FUN_ARG(0, cb);
-    GPhoto2 *gphoto = ObjectWrap::Unwrap<GPhoto2>(args.This());
+  REQ_FUN_ARG(0, cb);
+  GPhoto2 *gphoto = ObjectWrap::Unwrap<GPhoto2>(args.This());
 
-    TryCatch try_catch;
-    list_request *list_req =new list_request();
-    list_req->cb = Persistent<Function>::New(cb);
-    list_req->list = NULL;
-    list_req->gphoto = gphoto;
-    list_req->This = Persistent<Object>::New(args.This());
-    list_req->context  = gp_context_new();
+  TryCatch try_catch;
+  list_request *list_req = new list_request();
+  list_req->cb = Persistent<Function>::New(cb);
+  list_req->list = NULL;
+  list_req->gphoto = gphoto;
+  list_req->This = Persistent<Object>::New(args.This());
+  list_req->context = gp_context_new();
 
-    DO_ASYNC(list_req, Async_List, Async_ListCb);
+  DO_ASYNC(list_req, Async_List, Async_ListCb);
 
-    gphoto->Ref();
-    return Undefined();
+  gphoto->Ref();
+  return Undefined();
 }
 
-
 void GPhoto2::Async_LogCallback(uv_async_t *handle, int status) {
-  log_request *message = static_cast<log_request*>(handle->data);
+  log_request *message = static_cast<log_request *>(handle->data);
 
   HandleScope scope;
   Local<Value> args[] = {
@@ -89,44 +89,45 @@ void GPhoto2::Async_LogCallback(uv_async_t *handle, int status) {
   delete message;
 }
 
-void GPhoto2::LogHandler(GPLogLevel level, const char *domain, const char *str, void *data){
-  log_request *message    = new log_request();
+void GPhoto2::LogHandler(GPLogLevel level, const char *domain, const char *str,
+                          void *data) {
+  log_request *message = new log_request();
   static uv_async_t asyncLog;
 
-  message->level          = level;
-  message->domain         = std::string(domain);
-  message->message        = std::string(str);
-  message->cb             = static_cast<Function*>(data);
+  message->level = level;
+  message->domain = std::string(domain);
+  message->message = std::string(str);
+  message->cb = static_cast<Function *>(data);
   uv_async_init(uv_default_loop(), &asyncLog, GPhoto2::Async_LogCallback);
-  asyncLog.data = (void*)message;
+  asyncLog.data = static_cast<void *>(message);
 
   uv_async_send(&asyncLog);
-  sleep(0); // allow the default thread to process the log entry
+  sleep(0);  // allow the default thread to process the log entry
 }
 
-Handle<Value> GPhoto2::SetLogHandler(const Arguments &args){
+Handle<Value> GPhoto2::SetLogHandler(const Arguments &args) {
   HandleScope scope;
   REQ_ARGS(2);
   REQ_INT_ARG(0, level);
   REQ_FUN_ARG(1, cb);
 
   return cvv8::CastToJS(
-    gp_log_add_func((GPLogLevel)level, (GPLogFunc)GPhoto2::LogHandler, (void *)*Persistent<Function>::New(cb))
-  );
+    gp_log_add_func((GPLogLevel) level, (GPLogFunc) GPhoto2::LogHandler,
+                    static_cast<void *>(*Persistent<Function>::New(cb))));
 }
 
-void GPhoto2::Async_List(uv_work_t *req){
-    list_request *list_req = static_cast<list_request *>(req->data);
-    GPhoto2 *gphoto = list_req->gphoto;
-    GPPortInfoList *portInfoList = gphoto->getPortInfoList();
-    CameraAbilitiesList *abilitiesList = gphoto->getAbilitiesList();
-    gp_list_new(&list_req->list);
-    autodetect(list_req->list,  list_req->context, &portInfoList, &abilitiesList);
-    gphoto->setAbilitiesList(abilitiesList);
-    gphoto->setPortInfoList(portInfoList);
+void GPhoto2::Async_List(uv_work_t *req) {
+  list_request *list_req = static_cast<list_request *>(req->data);
+  GPhoto2 *gphoto = list_req->gphoto;
+  GPPortInfoList *portInfoList = gphoto->getPortInfoList();
+  CameraAbilitiesList *abilitiesList = gphoto->getAbilitiesList();
+  gp_list_new(&list_req->list);
+  autodetect(list_req->list, list_req->context, &portInfoList, &abilitiesList);
+  gphoto->setAbilitiesList(abilitiesList);
+  gphoto->setPortInfoList(portInfoList);
 }
-void  GPhoto2::Async_ListCb(uv_work_t *req, int status){
 
+void  GPhoto2::Async_ListCb(uv_work_t *req, int status) {
     HandleScope scope;
     int i;
 
@@ -137,23 +138,23 @@ void  GPhoto2::Async_ListCb(uv_work_t *req, int status){
     int count = gp_list_count(list_req->list);
     Local<Array> result = Array::New(count);
     argv[0] = result;
-    for(i=0; i<count; i++) {
-   		const char *name_, *port_;
-   		gp_list_get_name (list_req->list, i, &name_);
-   		gp_list_get_value (list_req->list, i, &port_);
+    for (i = 0; i < count; i++) {
+      const char *name_, *port_;
+      gp_list_get_name(list_req->list, i, &name_);
+      gp_list_get_value(list_req->list, i, &port_);
 
-      Local<Value> constructor_args[3];
+      Local<Value> _argv[3];
 
-      constructor_args[0] = External::New(list_req->gphoto);
-      constructor_args[1] = String::New(name_);
-      constructor_args[2] = String::New(port_);
+      _argv[0] = External::New(list_req->gphoto);
+      _argv[1] = String::New(name_);
+      _argv[2] = String::New(port_);
       TryCatch try_catch;
       // call the _javascript_ constructor to create a new Camera object
-   		Persistent<Object> js_camera(GPCamera::constructor_template->GetFunction()->NewInstance(3, constructor_args));
+      Persistent<Object> js_camera(
+        GPCamera::constructor_template->GetFunction()->NewInstance(3, _argv));
       js_camera->Set(String::NewSymbol("_gphoto2_ref_obj_"), list_req->This);
       result->Set(Number::New(i), Persistent<Object>::New(js_camera));
       if (try_catch.HasCaught()) node::FatalException(try_catch);
-
     }
 
     TryCatch try_catch;
@@ -169,17 +170,18 @@ void  GPhoto2::Async_ListCb(uv_work_t *req, int status){
     delete list_req;
 }
 
-int GPhoto2::openCamera(GPCamera *p){
+int GPhoto2::openCamera(GPCamera *p) {
   this->Ref();
-  //printf("Opening camera %d context=%p\n", __LINE__, this->context_);
+  // printf("Opening camera %d context=%p\n", __LINE__, this->context_);
   Camera *camera;
-  int ret = open_camera(&camera, p->getModel(), p->getPort(), this->portinfolist_, this->abilities_);
+  int ret = open_camera(&camera, p->getModel(), p->getPort(),
+                        this->portinfolist_, this->abilities_);
   p->setCamera(camera);
   return ret;
 }
 
-int GPhoto2::closeCamera(GPCamera *p){
+int GPhoto2::closeCamera(GPCamera *p) {
   this->Unref();
-  //printf("Closing camera %s", p->getModel().c_str());
+  // printf("Closing camera %s", p->getModel().c_str());
   return 0;
 }

--- a/src/gphoto.h
+++ b/src/gphoto.h
@@ -1,9 +1,13 @@
-#ifndef __GPHOTO_H
-#define __GPHOTO_H
-#include "binding.h"
-#include <unistd.h>
+/* Copyright 2012 Leonhardt Wille */
 
-using namespace v8;
+#ifndef SRC_GPHOTO_H_
+#define SRC_GPHOTO_H_
+
+#include <unistd.h>
+#include <string>
+#include "binding.h" // NOLINT
+
+using namespace v8;  // NOLINT
 
 class GPCamera;
 static Persistent<String> gphoto_test_symbol;
@@ -16,22 +20,24 @@ class GPhoto2: public node::ObjectWrap {
   CameraAbilitiesList  *abilities_;
 
   struct log_request {
-    int                      level;
-    std::string              domain;
-    std::string              message;
-    Persistent<Function>    cb;
+    int level;
+    std::string domain;
+    std::string message;
+    Persistent<Function> cb;
   };
-  static void Async_LogCallback(uv_async_t*, int);
 
   struct list_request {
-      Persistent<Function> cb;
-      GPhoto2             *gphoto;
-      CameraList	        *list;
-      Persistent<Object>	This;
-      GPContext           *context;
+    Persistent<Function> cb;
+    GPhoto2 *gphoto;
+    CameraList *list;
+    Persistent<Object> This;
+    GPContext *context;
   };
+
+  static void Async_LogCallback(uv_async_t*, int);
   static void Async_List(uv_work_t *req);
   static void Async_ListCb(uv_work_t *req, int status);
+
   public:
     static Persistent<FunctionTemplate> constructor_template;
     Camera * _camera;
@@ -42,16 +48,25 @@ class GPhoto2: public node::ObjectWrap {
     static Handle<Value> List(const Arguments &args);
     static Handle<Value> Test(const Arguments &args);
     static Handle<Value> SetLogHandler(const Arguments &args);
-    GPContext *getContext(){return this->context_;};
-
-    GPPortInfoList *getPortInfoList(){return this->portinfolist_;};
-    void setPortInfoList(GPPortInfoList *p){this->portinfolist_=p;};
-
-    CameraAbilitiesList *getAbilitiesList(){return this->abilities_;};
-    void setAbilitiesList(CameraAbilitiesList *p){this->abilities_=p;};
+    GPContext *getContext() {
+      return this->context_;
+    }
+    GPPortInfoList *getPortInfoList() {
+      return this->portinfolist_;
+    }
+    void setPortInfoList(GPPortInfoList *p) {
+      this->portinfolist_ = p;
+    }
+    CameraAbilitiesList *getAbilitiesList() {
+      return this->abilities_;
+    }
+    void setAbilitiesList(CameraAbilitiesList *p) {
+      this->abilities_ = p;
+    }
     int openCamera(GPCamera *camera);
     int closeCamera(GPCamera *camera);
-    static void LogHandler(GPLogLevel level, const char *domain, const char *str, void *data);
-
+    static void LogHandler(GPLogLevel level, const char *domain,
+                           const char *str, void *data);
 };
-#endif
+
+#endif  // SRC_GPHOTO_H_


### PR DESCRIPTION
This fixes the style of the C++ source files to conform to Google's style guidelines as identified by `cpplint.py`.
For automated style checks i would like to add a pre-commit hook and i wonder if `cpplint.py` should be added in the repo under a `/tools` folders for example (not everyone has `cpplint` installed).
The same script could also be used on Travis CI for redundancy.
