### PR TITLE
Fix descriptor leak in GPCamera::capturePreview()

### DIFF
--- a/src/camera_helpers.cc
+++ b/src/camera_helpers.cc
@@ -343,7 +343,7 @@ void GPCamera::capturePreview(take_picture_request *req) {
     retval = gp_camera_capture_preview(req->camera, file, req->context);
   }
 
-  if (!(req->target_path.empty() || req->socket_path.empty())) {
+  if (!req->target_path.empty() || !req->socket_path.empty()) {
     gp_file_free(file);
   }
 


### PR DESCRIPTION
Fixes `EMFILE` "Too many files opened" error, refs #61
