### PR TITLE
Added feature: Keep images on camera

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ GPhoto.list(function (list) {
     fs.writeFileSync(__dirname + '/picture.jpg', data);
   });
 
-  // Take picture with camera object obtained from list()
+  // Take picture and keep image on camera
   camera.takePicture({
     download: true,
     keep: true

--- a/README.md
+++ b/README.md
@@ -87,6 +87,14 @@ GPhoto.list(function (list) {
     fs.writeFileSync(__dirname + '/picture.jpg', data);
   });
 
+  // Take picture with camera object obtained from list()
+  camera.takePicture({
+    download: true,
+    keep: true
+  }, function (er, data) {
+    fs.writeFileSync(__dirname + '/picture.jpg', data);
+  });
+
   // Take picture without downloading immediately
   camera.takePicture({download: false}, function (er, path) {
     console.log(path);

--- a/src/camera.cc
+++ b/src/camera.cc
@@ -82,6 +82,11 @@ NAN_METHOD(GPCamera::TakePicture) {
     if (preVal->IsBoolean()) {
       picture_req->preview = preVal->ToBoolean()->Value();
     }
+
+    v8::Local<v8::Value> keepVal = options->Get(Nan::New("keep").ToLocalChecked());
+    if (keepVal->IsBoolean()) {
+      picture_req->keep = keepVal->ToBoolean()->Value();
+    }
   } else {
     REQ_FUN_ARG(0, cb);
     picture_req = new take_picture_request();

--- a/src/camera.h
+++ b/src/camera.h
@@ -70,6 +70,7 @@ class GPCamera : public Nan::ObjectWrap {
     int ret;
     bool download;
     bool preview;
+    bool keep;
     std::string path;
     std::string target_path;
     std::string socket_path;

--- a/src/camera_helpers.cc
+++ b/src/camera_helpers.cc
@@ -377,7 +377,7 @@ void GPCamera::downloadPicture(take_picture_request *req) {
     data = NULL;
   }
 
-  if (retval == GP_OK) {
+  if (retval == GP_OK && !req->keep) {
     retval = gp_camera_file_delete(req->camera, folder.str().c_str(),
                                    name.c_str(), req->context);
   }

--- a/test/camera.test.coffee
+++ b/test/camera.test.coffee
@@ -70,7 +70,18 @@ describe "node-gphoto2", ()->
 
      it 'and download it to a buffer', (done)->
        @timeout 10000
-       cameras[0].takePicture download:true, (er, data)->
+       cameras[0].takePicture download:true, keep:false, (er, data)->
+         try
+           should.not.exist er
+           data.should.be.an.instanceOf Buffer
+           checkJpegHeader data
+           done()
+         catch error
+           done error
+
+      it 'and keep it on camera', (done)->
+       @timeout 10000
+       cameras[0].takePicture download:true, keep:true, (er, data)->
          try
            should.not.exist er
            data.should.be.an.instanceOf Buffer


### PR DESCRIPTION
Tested 'keep: true' and 'keep: false' for function 'takePicture()'. Also wrote tests, but it is not tested if the picture really stays on the camera, because the `cameraPath` does not get returned when downloading a picture.

Closes #98