### PR TITLE
Allow preview to return a buffer

### DIFF
--- a/src/camera.cc
+++ b/src/camera.cc
@@ -129,7 +129,7 @@ void GPCamera::Async_CaptureCb(uv_work_t *req, int status) {
   } else if (capture_req->download && !capture_req->target_path.empty()) {
     argc = 2;
     argv[1] = Nan::New(capture_req->target_path).ToLocalChecked();
-  } else if (capture_req->data && capture_req->download) {
+  } else if (capture_req->data && (capture_req->download || capture_req->preview)) {
     argc = 2;
     v8::Local<v8::Object> globalObj = Nan::GetCurrentContext()->Global();
     v8::Local<v8::Function> bufferConstructor =

--- a/src/camera_helpers.cc
+++ b/src/camera_helpers.cc
@@ -389,15 +389,29 @@ void GPCamera::downloadPicture(take_picture_request *req) {
 void GPCamera::capturePreview(take_picture_request *req) {
   int retval;
   CameraFile *file;
+  const char *data;
 
   retval = getCameraFile(req, &file);
 
   if (retval == GP_OK) {
     retval = gp_camera_capture_preview(req->camera, file, req->context);
   }
-  if (!req->target_path.empty() || !req->socket_path.empty()) {
-    gp_file_free(file);
+
+  /* Fallback to downloading into buffer */
+  if (retval == GP_OK &&
+      req->target_path.empty() &&
+      req->socket_path.empty()) {
+    retval = gp_file_get_data_and_size(file, &data, &req->length);
+    if (retval == GP_OK && req->length != 0) {
+      /* `gp_file_free` will call `free` on `file->data` pointer, save data */
+      req->data = new char[req->length];
+      memmove(const_cast<char *>(req->data), data, req->length);
+    }
+    data = NULL;
   }
+
+  gp_file_free(file);
+
   req->ret = retval;
 }
 


### PR DESCRIPTION
It seemed odd to me that preview had to return a path to a file, so I made it return a buffer if no target/socket path is provided. (I needed this behaviour 😀)