### PR TITLE
Support for Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
   },
   "os": [
     "darwin",
-    "linux"
+    "linux",
+    "win32"
   ],
   "main": "index.js",
   "dependencies": {


### PR DESCRIPTION
Updated **_package.json_** to include **_win32_** in OS requirements.
Let me know if any other changes are required to provide support for windows.
The above change will allow _**npm install gphoto2**_ on Windows OS